### PR TITLE
Add support for qbittorrent  webui v3.2+

### DIFF
--- a/webuiapis/qBittorrentWebUI.js
+++ b/webuiapis/qBittorrentWebUI.js
@@ -6,18 +6,18 @@ RTA.clients.qBittorrentAdder = function(server, data, torrentname) {
 		target = "upload";
 	
 	//check if webui is using cookie auth (v3.2+)
-   	var xhr = new XMLHttpRequest();
-    var rootUrl = server.hostsecure ? "https" : "http" + "://" + server.host + ":" + server.port;
-    xhr.open("GET", rootUrl + "/version/qbittorrent", false, server.login, server.password);
+	var xhr = new XMLHttpRequest();
+	var rootUrl = server.hostsecure ? "https" : "http" + "://" + server.host + ":" + server.port;
+	xhr.open("GET", rootUrl + "/version/qbittorrent", false, server.login, server.password);
 	xhr.send();
-    if (xhr.status == 200)
-    {
-        var xhr = new XMLHttpRequest();
-        xhr.open("POST", rootUrl + "/login", false);
-        xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded; charset=utf-8");
-        xhr.send("username=" + encodeURIComponent(server.login) + "&password=" + encodeURIComponent(server.password));
-    }
-    
+	if (xhr.status == 200)
+	{
+		var xhr = new XMLHttpRequest();
+		xhr.open("POST", rootUrl + "/login", false);
+		xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded; charset=utf-8");
+		xhr.send("username=" + encodeURIComponent(server.login) + "&password=" + encodeURIComponent(server.password));
+	}
+
 	var xhr = new XMLHttpRequest();
 	xhr.open("POST", "http" + (server.hostsecure ? "s" : "") + "://" + server.host + ":" + server.port + "/command/" + target, true, server.login, server.password);
 	xhr.onreadystatechange = function(data) {

--- a/webuiapis/qBittorrentWebUI.js
+++ b/webuiapis/qBittorrentWebUI.js
@@ -7,7 +7,7 @@ RTA.clients.qBittorrentAdder = function(server, data, torrentname) {
 	
 	//check if webui is using cookie auth (v3.2+)
 	var xhr = new XMLHttpRequest();
-	var rootUrl = server.hostsecure ? "https" : "http" + "://" + server.host + ":" + server.port;
+	var rootUrl = (server.hostsecure ? "https" : "http") + "://" + server.host + ":" + server.port;
 	xhr.open("GET", rootUrl + "/version/qbittorrent", false, server.login, server.password);
 	xhr.send();
 	if (xhr.status == 200)

--- a/webuiapis/qBittorrentWebUI.js
+++ b/webuiapis/qBittorrentWebUI.js
@@ -5,6 +5,19 @@ RTA.clients.qBittorrentAdder = function(server, data, torrentname) {
 	else
 		target = "upload";
 	
+	//check if webui is using cookie auth (v3.2+)
+   	var xhr = new XMLHttpRequest();
+    var rootUrl = server.hostsecure ? "https" : "http" + "://" + server.host + ":" + server.port;
+    xhr.open("GET", rootUrl + "/version/qbittorrent", false, server.login, server.password);
+	xhr.send();
+    if (xhr.status == 200)
+    {
+        var xhr = new XMLHttpRequest();
+        xhr.open("POST", rootUrl + "/login", false);
+        xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded; charset=utf-8");
+        xhr.send("username=" + encodeURIComponent(server.login) + "&password=" + encodeURIComponent(server.password));
+    }
+    
 	var xhr = new XMLHttpRequest();
 	xhr.open("POST", "http" + (server.hostsecure ? "s" : "") + "://" + server.host + ":" + server.port + "/command/" + target, true, server.login, server.password);
 	xhr.onreadystatechange = function(data) {


### PR DESCRIPTION
Starting in version 3.2 qBittorrent switched from [digest authorization](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-Documentation-%28qBittorrent-v3.1.x%29#authorization) to [cookie based authentication](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-Documentation#authorization).  This pull request adds support for cookie based auth but should still be compatible with the older digest authorization.

This closes issue #145. 

A quick summary of the change:  A request to `/version/qbittorrent` was added to figure out what version of qBittorent is running.  The `/version/qbittorrent` page was added to the qBittorrent webui in version 3.2 and does not exist in prior versions.  If the webui responds to this request with an HTTP 200 status we know we are running a version which uses cookie authentication.  We can post the credentials to /login which sets the auth cookie.  The digest auth header is still included so qBittorrent webui versions prior to 3.2 still work.