### PR TITLE
Fence examples in CreateLinkCatchingFilters.md

### DIFF
--- a/CreateLinkCatchingFilters.md
+++ b/CreateLinkCatchingFilters.md
@@ -7,30 +7,30 @@ What follows is a brief explanation for the regexp newbie on how to get a workin
 
 
 ## Let's start with some random torrent download link ##
-Consider this link: **https://ssl.somesite.com/torrents.php?action=download&id=12345678&authkey=0a1b2c3d4e5f6g7h8i9j**
+Consider this link: `https://ssl.somesite.com/torrents.php?action=download&id=12345678&authkey=0a1b2c3d4e5f6g7h8i9j`
 
 We don't care about the protocol itself - merely the site's domain name itself should be kept in the pattern, so we strip the protocol and subdomain.
 
-We get: **somesite.com/torrents.php?action=download&id=12345678&authkey=0a1b2c3d4e5f6g7h8i9j**
+We get: `somesite.com/torrents.php?action=download&id=12345678&authkey=0a1b2c3d4e5f6g7h8i9j`
 
 ---
 
-The most interesting part after the domain name should be the name of the script that delivers the .torrent files for downloading, in this case it's **torrents.php**, so we leave that in. The parameter **action=download** identifies exactly what we want - to download a torrent - so that too is one that we won't touch. Next up is an ID - this is a number identifying the torrent on the tracker's side. Since we want to download other torrents as well that don't have this unique ID, we'll replace it with a placeholder that will match any kind of ID. Since those are numbers only, we use **\d+**. This catches any and all strings of numbers, and nothing but numbers.
+The most interesting part after the domain name should be the name of the script that delivers the .torrent files for downloading, in this case it's `torrents.php`, so we leave that in. The parameter `action=download` identifies exactly what we want - to download a torrent - so that too is one that we won't touch. Next up is an ID - this is a number identifying the torrent on the tracker's side. Since we want to download other torrents as well that don't have this unique ID, we'll replace it with a placeholder that will match any kind of ID. Since those are numbers only, we use `\d+`. This catches any and all strings of numbers, and nothing but numbers.
 
-Therefore: **somesite.com/torrents.php?action=download&id=\d+&authkey=0a1b2c3d4e5f6g7h8i9j**
+Therefore: `somesite.com/torrents.php?action=download&id=\d+&authkey=0a1b2c3d4e5f6g7h8i9j`
 
 ---
 
 Now what we have left is the parameter containing the authkey. Since our pattern before that parameter already contains a lot of information that will prevent it from matching links it shouldn't, we might as well just cut it off entirely. Alternatively, we could replace the value of authkey to accept a string containing anything, and this anything may be of arbitrary length.
 
-Thus: **somesite.com/torrents.php?action=download&id=\d+**
+Thus: `somesite.com/torrents.php?action=download&id=\d+`
 
-Alternatively: **somesite.com/torrents.php?action=download&id=\d+&authkey=.+?**
+Alternatively: `somesite.com/torrents.php?action=download&id=\d+&authkey=.+?`
 
 ---
 
 As a last step, we will have to make this pattern actually work: some of the characters that were part of the original url are characters that have a specific meaning in regular expressions, those are for the most part "." (dot), "/" (forward slash) and "?" (question mark). To render them inert, we place a "\" (backslash) in front of them - we "escape" them:
 
-Finally: **somesite\.com\/torrents\.php\?action=download&id=\d+**
+Finally: `somesite\.com\/torrents\.php\?action=download&id=\d+`
 
 This will match any link that follows the naming pattern of the original link.

--- a/CreateLinkCatchingFilters.md
+++ b/CreateLinkCatchingFilters.md
@@ -29,7 +29,7 @@ Alternatively: `somesite.com/torrents.php?action=download&id=\d+&authkey=.+?`
 
 ---
 
-As a last step, we will have to make this pattern actually work: some of the characters that were part of the original url are characters that have a specific meaning in regular expressions, those are for the most part "." (dot), "/" (forward slash) and "?" (question mark). To render them inert, we place a "\" (backslash) in front of them - we "escape" them:
+As a last step, we will have to make this pattern actually work: some of the characters that were part of the original url are characters that have a specific meaning in regular expressions, those are for the most part "." (dot), "/" (forward slash) and "?" (question mark). To render them inert, we place a "\\" (backslash) in front of them - we "escape" them:
 
 Finally: `somesite\.com\/torrents\.php\?action=download&id=\d+`
 


### PR DESCRIPTION
Since the Github wiki software by default eats certain single backslashes, many of the backslashes were not displaying in the repo's Wiki section, making the examples incorrect. This changes all of the sample strings (regexps) from bolded text to \`-fenced strings, which preserves the intended backslashes without having to double them.

(Confusingly, the wiki renderer, like the comment renderer here, only eats backslashes if it recognizes them as escaping a special character. So, for example, `somesite\.com\/torrents\.php\?action=download&id=\d+` will display as: somesite\.com\/torrents\.php\?action=download&id=\d+
The backslash in `\d` still shows up, because it assumes you don't want to escape the letter d. But all of the others are eaten, because `\/`, `\.`, and `\?` are parsed as escapes.)