### PR TITLE
Make ruTorrent show success

### DIFF
--- a/webuiapis/ruTorrentWebUI.js
+++ b/webuiapis/ruTorrentWebUI.js
@@ -23,10 +23,14 @@ RTA.clients.ruTorrentAdder = function(server, data, label, dir) {
 	if(server.rutorrentaddpaused)
 		url += "&torrents_start_stopped=1";
 	
+	// ruTorrent seems to have different authentication methods sometimes - add both
 	xhr.open("POST", url, true, server.login, server.password);
+	xhr.setRequestHeader("Authorization", "Basic " + btoa(server.login + ":" + server.password));
+
 	xhr.onreadystatechange = function(data) {
 		if(xhr.readyState == 4 && xhr.status == 200) {
-			if(/.*addTorrentSuccess.*/.exec(xhr.responseText)) {
+			// Some hosts override the response page, but the url contains the success code
+			if(/.*addTorrentSuccess.*/.exec(xhr.responseText) || /.*result\[\]=Success.*/.exec(xhr.responseURL)) {
 				RTA.displayResponse("Success", "Torrent added successfully.");
 			} else {
 				RTA.displayResponse("Failure", "Server didn't accept data:\n" + xhr.status + ": " + xhr.responseText, true);


### PR DESCRIPTION
Tested chrome 67, Feral hosting ruTorrent.

I've always that the problem that adding works, but it shows an error code due to my server overriding the success page. I noticed that it seems to follow a redirect to a success url though, so I've added a regex on the `success` GET var.

I also looked at the changes which were made here: https://github.com/bogenpirat/remote-torrent-adder/issues/198#issuecomment-292947392. My server was authenticating fine anyway, so I can't really test that problem, but I figured that adding the authentication both ways shouldn't cause a problem - it doesn't seem to for me.