### PR TITLE
Fixes "http error 0" in ruTorrent client

### DIFF
--- a/webuiapis/ruTorrentWebUI.js
+++ b/webuiapis/ruTorrentWebUI.js
@@ -70,7 +70,8 @@ autoDirectory:
 	if(server.rutorrentaddpaused)
 		url += "&torrents_start_stopped=1";
 	
-	xhr.open("POST", url, true, server.login, server.password);
+	xhr.open("POST", url, true);
+	xhr.setRequestHeader('Authorization', 'Basic ' + btoa(server.login + ":" + server.password));
 	xhr.onreadystatechange = function(data) {
 		if(xhr.readyState == 4 && xhr.status == 200) {
 			if(/.*addTorrentSuccess.*/.exec(xhr.responseText) || /.*result\[\]=Success.*/.exec(xhr.responseURL)) {


### PR DESCRIPTION
On attempting to add a torrent to a rutorrent client, extension was throwing the following error, as described in issue #260:
 "Access to XMLHttpRequest at 'https://\<serverdetails\>/rutorrent/php/addtorrent.php?' from origin 'chrome-extension://dnmfignmbknndmbmoafnmccbnjoloclg' has been blocked by CORS policy: Redirect location '' contains a username and password, which is disallowed for cross-origin requests."

Reproduced using Chrome Version 80.0.3987.149 (Official Build) (64-bit), so tested the solution suggested by sieempi in the issue thread, and the issue no longer occurs.

Issue had been present for me for a while, using Remote Torrent Adder 1.2.15 (or lower) on whichever version of Chrome was present on my system.