### PR TITLE
Add path parameter for TransmissionWebUI

### DIFF
--- a/miscapis/config.js
+++ b/miscapis/config.js
@@ -1,6 +1,7 @@
 RTA.clients.config.getConfig = function(client, name) {
 	var clientMap = {
 		"ruTorrent WebUI" : RTA.clients.config.rutorrent,
+		"Transmission WebUI" : RTA.clients.config.transmission,
 		"Torrentflux WebUI" : RTA.clients.config.torrentflux,
 		"uTorrent WebUI" : RTA.clients.config.utorrent,
 		"Deluge WebUI" : RTA.clients.config.deluge,
@@ -140,6 +141,15 @@ RTA.clients.config.rutorrent = multiline(function(){/*
 						<span class="tip" style="font-family: Courier New;">&lt;tracker url&gt;,&lt;directory to assign&gt;</span><br />
 						<span class="tip">e.g.:</span><br />
 						<span class="tip" style="font-family: Courier New;">torrent.ubuntu.com,/media/library/linux-distros/</span></td>
+				</tr>
+			</tbody>
+			*/});
+
+RTA.clients.config.transmission = multiline(function(){/*
+			<tbody name="transmissionwebuispecifics" class="specifics">
+				<tr>
+					<td><span class="title">Path</span><br />(optional)</td>
+					<td><input type="text" name="transmissionpath" /></td>
 				</tr>
 			</tbody>
 			*/});

--- a/webuiapis/TransmissionWebUI.js
+++ b/webuiapis/TransmissionWebUI.js
@@ -12,10 +12,13 @@ RTA.clients.transmissionAdder = function(server, torrentdata) {
 			
 			var message;
 			if(torrentdata.substring(0,7) == "magnet:") {
-				message = JSON.stringify({"method": "torrent-add", "arguments": {"paused": "false", "filename": torrentdata}});
+				message = {"method": "torrent-add", "arguments": {"paused": "false", "filename": torrentdata}};
 			} else {
-				message = JSON.stringify({"method": "torrent-add", "arguments": {"metainfo": b64_encode(data)}});
+				message = {"method": "torrent-add", "arguments": {"metainfo": b64_encode(data)}};
 			}
+
+			if (server.transmissionpath && server.transmissionpath.length > 0)
+				message["arguments"]["download-dir"] = server.transmissionpath;
 			
 			fetch(apiUrl, {
 				method: 'POST',
@@ -23,7 +26,7 @@ RTA.clients.transmissionAdder = function(server, torrentdata) {
 					"X-Transmission-Session-Id": sessionId,
 					"Content-Type": "application/json; charset=UTF-8"
 				},
-				body: message
+				body: JSON.stringify(message)
 			})
 			.then(RTA.handleFetchError)
 			.then(response => response.json())


### PR DESCRIPTION
Hi

I've added a "path" parameter for TransmissionWebUI.

I use it to specify the destination path : using multiple servers in RemoteTorrentAdder, all with the same host but different destination paths.

Now I can select the download path easily (example : "parent" / "children" folders)