### PR TITLE
[rutorrent] fix cors policy

### DIFF
--- a/webuiapis/ruTorrentWebUI.js
+++ b/webuiapis/ruTorrentWebUI.js
@@ -102,7 +102,8 @@ autoDirectory:
 	fetch(url, {
 		method: 'POST',
 		headers: headers,
-		body: message
+		body: message,
+		mode: 'no-cors',
 	}).then(RTA.handleFetchError)
 	.then(response => {
 		if(/.*result\[\]=Success.*/.exec(response.url)) {


### PR DESCRIPTION
For sites with CORS policy set, the `fetch` request will fail with network error. This disables the CORS policy for ruTorrent.