### PR TITLE
fix(qbittorrent): accept any 2xx on auth login (qB 5.2)

### DIFF
--- a/src/webuis/qbittorrent-webui.ts
+++ b/src/webuis/qbittorrent-webui.ts
@@ -27,7 +27,7 @@ export class QBittorrentWebUI extends TorrentWebUI {
                 },
                 body: authenticationBody
             }).then(response => {
-                if (response.status == 200) {
+                if (response.ok) {
                     resolve();
                 } else {
                     reject(new Error("Authentication failed"));


### PR DESCRIPTION
## Summary

qBittorrent 5.2.0 (released 2026-05-03) introduced two breaking changes to its WebUI auth API:

1. `POST /api/v2/auth/login` now returns **204 No Content** with an empty body on successful login, instead of `200 OK` with body `Ok.`.
2. The session cookie was renamed from `SID` to `QBT_SID_<port>` (e.g. `QBT_SID_8080`).

Verified against the `release-5.2.0` source tree (`src/webui/webapplication.cpp`):

- The login response status is overridden to `204` whenever `result.data.isNull()`, which is the case for `loginAction()`.
- `m_sessionCookieName = u"QBT_SID_"_s + QString::number(pref->getWebUIPort())`.

The strict `response.status == 200` check in `QBittorrentWebUI.authenticate()` treats the new `204` response as authentication failure, breaking torrent uploads against any qBittorrent 5.2 server.

## Fix

Replace the strict status check with `response.ok` so that any 2xx is accepted as success. This covers `204` (5.2+) and remains compatible with `200` (5.1 and earlier).

The cookie rename does **not** require any code change here — the extension never reads the session cookie by name, it relies on the browser cookie jar to round-trip whatever cookie qBittorrent sets.

## Diff

One line, in `src/webuis/qbittorrent-webui.ts`:

```diff
-                if (response.status == 200) {
+                if (response.ok) {
```

Note that the base `TorrentWebUI.fetch()` already throws on `!res.ok`, so any non-2xx response is rejected upstream of this check; the strict 200 was therefore both incorrect for 5.2 and redundant for older versions.

## Test plan

- [x] `npm run build` completes cleanly (rollup + popup + options + notifications, no TS errors).
- [ ] Manual upload against a qBittorrent 5.2.x WebUI instance (login + add magnet + add .torrent).
- [ ] Manual regression test against a qBittorrent 5.1.x WebUI instance to confirm no regression.

## Out of scope (flagged for follow-up)

- `qbittorrent-webui.ts:73` (`sendRequest()` for `/api/v2/torrents/add`) uses the same strict `status === 200` pattern. If a future qBittorrent release changes the add endpoint to return `204` for empty-body responses it will hit the same bug. Worth checking in a follow-up.
- Other client classes (`porla-webui.ts`, `elementum-webui.ts`, `tixati-webui.ts`, `ttorrent-webui.ts`, `qnapdownloadstation-webui.ts`) also use strict-200 checks. Lower risk because their server APIs have not changed, but the same hardening is advisable.
- `deluge-webui.ts`, `flood-webui.ts`, `transmission-webui.ts` already combine the status check with protocol-level signals (JSON-RPC payload, 200/202/409 multi-status). Considered fine as-is.