### PR TITLE
Bugfix/cloudflare anti bot mitigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4795,9 +4795,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.16",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "dev": true,
             "funding": [
                 {

--- a/src/content-script/rta.ts
+++ b/src/content-script/rta.ts
@@ -2,8 +2,11 @@ import { observe } from './mutations';
 import { deriveLinkLabel, isMagnetLink } from './link-labels';
 import {deserializeObject} from '../util/serializer';
 import {
+    FetchTorrentInPageMessage,
     GetLinkCatchingConfig,
     GetPageLinksMessage,
+    type IFetchTorrentInPageMessage,
+    type IFetchTorrentInPageResponse,
     type ILinkCatchingConfig,
     type IPageLinkInfo,
     type IPageLinksResponse,
@@ -13,6 +16,7 @@ import {
 } from '../models/messages';
 import { PreAddTorrentMessage } from '../models/messages';
 import { isMatchedByRegexes } from '../util/utils';
+import { fetchTorrentInPage } from './torrent-fetch';
 
 
 let numFoundLinks: number;
@@ -20,10 +24,20 @@ let foundLinks: IPageLinkInfo[];
 let seenLinkUrls: Set<string>;
 loadSettingsAndRegisterActions();
 
-chrome.runtime.onMessage.addListener((message: { action?: string }, _sender, sendResponse: (response: IPageLinksResponse) => void) => {
+chrome.runtime.onMessage.addListener((
+    message: { action?: string },
+    _sender,
+    sendResponse: (response: IPageLinksResponse | IFetchTorrentInPageResponse) => void
+) => {
     if (message?.action === GetPageLinksMessage.action) {
         sendResponse({ links: foundLinks });
         return false;
+    }
+    if (message?.action === FetchTorrentInPageMessage.action) {
+        fetchTorrentInPage((message as IFetchTorrentInPageMessage).url)
+            .then(fetched => sendResponse({ fetched }))
+            .catch((error: unknown) => sendResponse({ error: (error as Error)?.message ?? String(error) }));
+        return true;
     }
     return false;
 });

--- a/src/content-script/torrent-fetch.ts
+++ b/src/content-script/torrent-fetch.ts
@@ -1,0 +1,33 @@
+import { type IFetchedTorrentFile } from "../models/messages";
+import { bytesToBase64, MAX_TORRENT_FILE_BYTES } from "../util/torrent-bytes";
+
+export async function fetchTorrentInPage(url: string): Promise<IFetchedTorrentFile> {
+    const response = await fetch(url, {
+        mode: isSameOrigin(url) ? "same-origin" : "cors",
+        credentials: "include",
+        redirect: "follow"
+    });
+
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    if (bytes.byteLength > MAX_TORRENT_FILE_BYTES) {
+        throw new Error(`Response is ${bytes.byteLength} bytes, which is far too large for a torrent file.`);
+    }
+
+    return {
+        ok: response.ok,
+        status: response.status,
+        statusText: response.statusText,
+        contentType: response.headers.get("Content-Type"),
+        cfMitigated: response.headers.get("cf-mitigated"),
+        finalUrl: response.url || url,
+        base64: bytesToBase64(bytes)
+    };
+}
+
+function isSameOrigin(url: string): boolean {
+    try {
+        return new URL(url, location.href).origin === location.origin;
+    } catch {
+        return false;
+    }
+}

--- a/src/models/messages.ts
+++ b/src/models/messages.ts
@@ -46,6 +46,10 @@ export const TestConnectionMessage: IMessagable = {
     action: "testConnection"
 }
 
+export const FetchTorrentInPageMessage: IMessagable = {
+    action: "fetchTorrentInPage"
+}
+
 export interface IAddTorrentMessage extends IPreAddTorrentMessage {
     webUiId: string;
     config: TorrentUploadConfig;
@@ -61,6 +65,28 @@ export interface IAddTorrentMessageWithLabelAndDir extends IMessagable {
 export interface IPreAddTorrentMessage extends IMessagable {
     url: string;
     webUiId?: string | null;
+    tabId?: number | null;
+    frameId?: number | null;
+    pageUrl?: string | null;
+}
+
+export interface IFetchTorrentInPageMessage extends IMessagable {
+    url: string;
+}
+
+export interface IFetchedTorrentFile {
+    ok: boolean;
+    status: number;
+    statusText: string;
+    contentType: string | null;
+    cfMitigated: string | null;
+    finalUrl: string;
+    base64: string;
+}
+
+export interface IFetchTorrentInPageResponse {
+    fetched?: IFetchedTorrentFile;
+    error?: string;
 }
 
 export interface IUpdateActionBadgeTextMessage extends IMessagable {

--- a/src/popup/app/PageLinksView.tsx
+++ b/src/popup/app/PageLinksView.tsx
@@ -16,6 +16,7 @@ type LoadState =
 
 export default function PageLinksView() {
   const [state, setState] = useState<LoadState>({ status: 'loading' });
+  const [sourceTab, setSourceTab] = useState<{ tabId: number; pageUrl: string | null } | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -26,6 +27,7 @@ export default function PageLinksView() {
           if (!cancelled) setState({ status: 'empty' });
           return;
         }
+        if (!cancelled) setSourceTab({ tabId: tab.id, pageUrl: tab.url ?? null });
         const response = (await chrome.tabs.sendMessage(tab.id, GetPageLinksMessage, { frameId: 0 })) as
           | IPageLinksResponse
           | undefined;
@@ -44,7 +46,13 @@ export default function PageLinksView() {
   }, []);
 
   const addLink = (url: string) => {
-    chrome.runtime.sendMessage({ action: PreAddTorrentMessage.action, url } as IPreAddTorrentMessage);
+    chrome.runtime.sendMessage({
+      action: PreAddTorrentMessage.action,
+      url,
+      tabId: sourceTab?.tabId ?? null,
+      frameId: 0,
+      pageUrl: sourceTab?.pageUrl ?? null,
+    } as IPreAddTorrentMessage);
     window.close();
   };
 

--- a/src/util/context-menu.ts
+++ b/src/util/context-menu.ts
@@ -2,6 +2,7 @@ import { type TorrentWebUI } from "../models/webui";
 import OnClickData = chrome.contextMenus.OnClickData;
 import Tab = chrome.tabs.Tab;
 import { type IPreAddTorrentMessage, PreAddTorrentMessage } from "../models/messages";
+import { type TorrentDownloadContext } from "./download";
 import { addTorrentToWebUiById, dispatchPreAddTorrent } from "./messaging";
 import { loadWebUis } from "./webuis";
 
@@ -66,6 +67,7 @@ async function handleContextMenuClick(onClickData: OnClickData, tab?: Tab): Prom
     }
 
     const url = onClickData.linkUrl ?? "";
+    const context = resolveDownloadContext(onClickData, tab);
 
     const [singleTarget] = targetWebUis;
     if (targetWebUis.length === 1 && singleTarget) {
@@ -74,11 +76,11 @@ async function handleContextMenuClick(onClickData: OnClickData, tab?: Tab): Prom
             webUiId: singleTarget.settings.id,
             url
         };
-        await dispatchPreAddTorrent(preAddTorrentMessage, await resolveWindowId(tab));
+        await dispatchPreAddTorrent(preAddTorrentMessage, await resolveWindowId(tab), context);
         return;
     }
 
-    targetWebUis.forEach(webUi => addTorrentToWebUiById(webUi.settings.id, url, null));
+    targetWebUis.forEach(webUi => addTorrentToWebUiById(webUi.settings.id, url, null, context));
 }
 
 function resolveTargetWebUis(menuItemId: string, allWebUis: TorrentWebUI[]): TorrentWebUI[] {
@@ -91,6 +93,14 @@ function resolveTargetWebUis(menuItemId: string, allWebUis: TorrentWebUI[]): Tor
     const index = Number.parseInt(menuItemId.slice(PER_SERVER_MENU_PREFIX.length), 10);
     const webUiAtIndex = Number.isInteger(index) ? allWebUis[index] : undefined;
     return webUiAtIndex ? [webUiAtIndex] : [];
+}
+
+function resolveDownloadContext(onClickData: OnClickData, tab?: Tab): TorrentDownloadContext {
+    return {
+        tabId: tab?.id ?? null,
+        frameId: onClickData.frameId ?? 0,
+        pageUrl: onClickData.frameUrl ?? onClickData.pageUrl ?? tab?.url ?? null
+    };
 }
 
 async function resolveWindowId(tab?: Tab): Promise<number> {

--- a/src/util/cors-tricks.ts
+++ b/src/util/cors-tricks.ts
@@ -90,6 +90,10 @@ export async function executeMethodWrappedWithReferer<T>(method: () => Promise<T
                             header: "Referer",
                             operation: "set",
                             value: referer
+                        },
+                        {
+                            header: "Origin",
+                            operation: "remove"
                         }
                     ]
                 },

--- a/src/util/download.ts
+++ b/src/util/download.ts
@@ -1,46 +1,163 @@
 import { type DecodedTorrent } from "../models/decoded-torrent";
+import {
+    FetchTorrentInPageMessage,
+    type IFetchTorrentInPageMessage,
+    type IFetchTorrentInPageResponse
+} from "../models/messages";
 import { type Torrent } from "../models/torrent";
 import { getTorrentNameFromLink } from "./parsers";
 import { decodeTorrentBytes } from "./bencode-decode";
 import { executeMethodWrappedWithReferer } from "./cors-tricks";
 import { getBaseUrl } from "./utils";
+import { base64ToBytes, MAX_TORRENT_FILE_BYTES } from "./torrent-bytes";
 import { buildTorrentFromDecodedData, buildTorrentFromMagnetLink } from "./torrent-source";
 
-export async function downloadTorrent(url: string): Promise<Torrent> {
+export interface TorrentDownloadContext {
+    tabId?: number | null;
+    frameId?: number | null;
+    pageUrl?: string | null;
+}
+
+interface FetchedTorrentFile {
+    ok: boolean;
+    status: number;
+    statusText: string;
+    contentType: string | null;
+    cfMitigated: string | null;
+    finalUrl: string;
+    bytes: Uint8Array<ArrayBuffer>;
+}
+
+const CLOUDFLARE_CHALLENGE_STATUSES = [403, 429, 503];
+
+const CLOUDFLARE_CHALLENGE_MARKERS = [
+    "/cdn-cgi/challenge-platform",
+    "challenges.cloudflare.com",
+    "__cf_chl",
+    "cf_chl_opt",
+    "cf-browser-verification"
+];
+
+export class CloudflareChallengeError extends Error {
+    readonly challengeUrl: string;
+
+    constructor(challengeUrl: string) {
+        super("Cloudflare wants to check this browser. Open the link in a tab, complete the check, then add the torrent again.");
+        this.name = "CloudflareChallengeError";
+        this.challengeUrl = challengeUrl;
+    }
+}
+
+export async function downloadTorrent(url: string, context: TorrentDownloadContext = {}): Promise<Torrent> {
     if (url.startsWith("magnet:")) {
         return buildTorrentFromMagnetLink(url);
     }
 
+    const fetched = await fetchTorrentFile(url, context);
+
+    if (isCloudflareChallenge(fetched)) {
+        throw new CloudflareChallengeError(fetched.finalUrl || url);
+    }
+    if (!fetched.ok) {
+        throw new Error(`Status not OK: ${fetched.status} ${fetched.statusText}`);
+    }
+
+    const decodedTorrentData = decodeTorrentDataAndValidate(fetched);
+
+    return buildTorrentFromDecodedData(decodedTorrentData, getTorrentNameFromLink(url), new Blob([fetched.bytes]));
+}
+
+async function fetchTorrentFile(url: string, context: TorrentDownloadContext): Promise<FetchedTorrentFile> {
+    return await fetchTorrentFileFromPage(url, context) ?? await fetchTorrentFileFromWorker(url, context);
+}
+
+async function fetchTorrentFileFromPage(url: string, context: TorrentDownloadContext): Promise<FetchedTorrentFile | null> {
+    if (context.tabId === undefined || context.tabId === null || context.tabId < 0) {
+        return null;
+    }
+
+    const message: IFetchTorrentInPageMessage = { action: FetchTorrentInPageMessage.action, url };
+    let response: IFetchTorrentInPageResponse | undefined;
+    try {
+        response = await chrome.tabs.sendMessage(context.tabId, message, { frameId: context.frameId ?? 0 }) as IFetchTorrentInPageResponse | undefined;
+    } catch (error) {
+        console.warn("No content script answered in tab " + context.tabId + "; downloading from the service worker instead.", error);
+        return null;
+    }
+
+    if (!response?.fetched) {
+        console.warn("The page could not download the torrent; downloading from the service worker instead.", response?.error);
+        return null;
+    }
+
+    return {
+        ok: response.fetched.ok,
+        status: response.fetched.status,
+        statusText: response.fetched.statusText,
+        contentType: response.fetched.contentType,
+        cfMitigated: response.fetched.cfMitigated,
+        finalUrl: response.fetched.finalUrl,
+        bytes: base64ToBytes(response.fetched.base64)
+    };
+}
+
+async function fetchTorrentFileFromWorker(url: string, context: TorrentDownloadContext): Promise<FetchedTorrentFile> {
+    const referer = context.pageUrl || getBaseUrl(url);
+
     let response: Response;
     try {
-        response = await executeMethodWrappedWithReferer(() => fetch(url), url, getBaseUrl(url));
+        response = await executeMethodWrappedWithReferer(() => fetch(url, { credentials: "include" }), url, referer);
     } catch (error) {
         throw new Error("Failed to fetch torrent file: " + (error as Error).message, { cause: error });
     }
-    if (!response.ok) {
-        throw new Error(`Status not OK: ${response.status} ${response.statusText}`);
+
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    if (bytes.byteLength > MAX_TORRENT_FILE_BYTES) {
+        throw new Error(`Response is ${bytes.byteLength} bytes, which is far too large for a torrent file.`);
     }
 
-    const torrentBlob: Blob = await response.blob();
-    const decodedTorrentData = decodeTorrentDataAndValidate(response, new Uint8Array(await torrentBlob.arrayBuffer()));
-
-    return buildTorrentFromDecodedData(decodedTorrentData, getTorrentNameFromLink(url), torrentBlob);
+    return {
+        ok: response.ok,
+        status: response.status,
+        statusText: response.statusText,
+        contentType: response.headers.get("Content-Type"),
+        cfMitigated: response.headers.get("cf-mitigated"),
+        finalUrl: response.url || url,
+        bytes
+    };
 }
 
-function decodeTorrentDataAndValidate(response: Response, torrentData: Uint8Array): DecodedTorrent {
-    try {
-        return decodeTorrentBytes(torrentData);
-    } catch (error) {
-        let contentType = response.headers.get("Content-Type");
-        if (contentType) {
-            const semicolonPos = contentType.indexOf(";");
-            contentType = contentType.slice(0, semicolonPos).trim();
-        } else {
-            contentType = "unknown"
-        }
-
-        console.error("Invalid torrent data received", torrentData);
-
-        throw new Error("Received " + contentType + " instead of a torrent file. Please check the devtools view for details.", { cause: error });
+function isCloudflareChallenge(fetched: FetchedTorrentFile): boolean {
+    if (fetched.cfMitigated?.toLowerCase().includes("challenge")) {
+        return true;
     }
+    if (!CLOUDFLARE_CHALLENGE_STATUSES.includes(fetched.status)) {
+        return false;
+    }
+
+    const contentType = fetched.contentType?.toLowerCase() ?? "";
+    if (contentType && !contentType.includes("text/html")) {
+        return false;
+    }
+
+    const body = new TextDecoder().decode(fetched.bytes.subarray(0, 64 * 1024));
+    return CLOUDFLARE_CHALLENGE_MARKERS.some(marker => body.includes(marker));
+}
+
+function decodeTorrentDataAndValidate(fetched: FetchedTorrentFile): DecodedTorrent {
+    try {
+        return decodeTorrentBytes(fetched.bytes);
+    } catch (error) {
+        console.error("Invalid torrent data received", fetched.bytes);
+
+        throw new Error("Received " + describeContentType(fetched.contentType) + " instead of a torrent file. Please check the devtools view for details.", { cause: error });
+    }
+}
+
+function describeContentType(contentType: string | null): string {
+    if (!contentType) {
+        return "unknown";
+    }
+    const semicolonPos = contentType.indexOf(";");
+    return (semicolonPos < 0 ? contentType : contentType.slice(0, semicolonPos)).trim();
 }

--- a/src/util/messaging.ts
+++ b/src/util/messaging.ts
@@ -17,13 +17,14 @@ import {
     type ITestNotificationMessage,
     type IMessagable
 } from "../models/messages";
+import { type RTASettings } from "../models/settings";
 import { type Torrent, type TorrentUploadConfig } from "../models/torrent";
 import { type ConnectionTestResult, type TorrentAddingResult, type TorrentWebUI, type WebUISettings } from "../models/webui";
 import { WebUIFactory } from "../models/clients";
 import { openActionPopup, POPUP_PAGE, updateBadgeText } from "./action";
 import { getAutoDirResult, getAutoLabelResult } from "./auto-label-dir-matcher";
 import { executeMethodWrappedWithOriginStripped } from "./cors-tricks";
-import { downloadTorrent } from "./download";
+import { CloudflareChallengeError, downloadTorrent, type TorrentDownloadContext } from "./download";
 import { showNotification } from "./notifications";
 import { serializeSettings, serializeObject, deserializeSettings } from "./serializer";
 import { clearBufferedTorrent, readBufferedTorrent, saveBufferedTorrent } from "./buffered-torrent";
@@ -101,9 +102,14 @@ export function registerMessageListener(): void {
                 }
                 case PreAddTorrentMessage.action: {
                     willRespondAsync = true;
+                    const preAddTorrentMessage = message as IPreAddTorrentMessage;
                     chrome.windows.getLastFocused().then(lastFocusedWindow => {
                         try {
-                            dispatchPreAddTorrent(message as IPreAddTorrentMessage, sender.tab?.windowId ?? lastFocusedWindow.id ?? 0);
+                            dispatchPreAddTorrent(
+                                preAddTorrentMessage,
+                                sender.tab?.windowId ?? lastFocusedWindow.id ?? 0,
+                                resolveDownloadContext(preAddTorrentMessage, sender)
+                            );
                             finish({});
                         } catch (e) { respondWithError(e); }
                     }).catch(respondWithError);
@@ -112,7 +118,12 @@ export function registerMessageListener(): void {
                 case AddTorrentMessage.action: {
                     willRespondAsync = true;
                     const addTorrentMessage = message as IAddTorrentMessage;
-                    addTorrentToWebUiById(addTorrentMessage.webUiId, addTorrentMessage.url, addTorrentMessage.config)
+                    addTorrentToWebUiById(
+                        addTorrentMessage.webUiId,
+                        addTorrentMessage.url,
+                        addTorrentMessage.config,
+                        resolveDownloadContext(addTorrentMessage, sender)
+                    )
                         .then(() => finish({}))
                         .catch(respondWithError);
                     break;
@@ -140,13 +151,29 @@ export function registerMessageListener(): void {
     });
 }
 
-export async function dispatchPreAddTorrent(message: IPreAddTorrentMessage, windowId: number): Promise<void> {
+export function resolveDownloadContext(message: IPreAddTorrentMessage, sender: chrome.runtime.MessageSender): TorrentDownloadContext {
+    const senderPageUrl = sender.tab ? sender.url ?? sender.tab.url ?? null : null;
+    return {
+        tabId: sender.tab?.id ?? message.tabId ?? null,
+        frameId: (sender.tab ? sender.frameId : message.frameId) ?? 0,
+        pageUrl: senderPageUrl ?? message.pageUrl ?? null
+    };
+}
+
+export async function dispatchPreAddTorrent(message: IPreAddTorrentMessage, windowId: number, context: TorrentDownloadContext = {}): Promise<void> {
     const settingsProvider = new Settings();
     const allWebUis = await getAllWebUis(settingsProvider);
     const webUiById = await getWebUiById(message.webUiId ?? "", settingsProvider);
     const webUi = webUiById ?? allWebUis[0] ?? null;
     if (webUi && webUi.settings.showPerTorrentConfigSelector) {
-        const torrent = await downloadTorrent(message.url);
+        let torrent: Torrent;
+        try {
+            torrent = await downloadTorrent(message.url, context);
+        } catch (error) {
+            console.error("Error downloading torrent:", error);
+            notifyDownloadFailure(error, await settingsProvider.loadSettings(), addTrailingSlash(webUi.createBaseUrl()));
+            return;
+        }
         await saveBufferedTorrent({ torrent, webUiSettings: webUi.settings });
         if (webUi.settings.useAlternativeLabelDirChooser) {
             chrome.windows.create({
@@ -161,14 +188,14 @@ export async function dispatchPreAddTorrent(message: IPreAddTorrentMessage, wind
             openActionPopup(windowId);
         }
     } else {
-        downloadAndAddTorrentToWebUi(webUi, message.url, null, message);
+        downloadAndAddTorrentToWebUi(webUi, message.url, null, message, context);
     }
 }
 
 
-export async function addTorrentToWebUiById(webUiId: string, url: string, config: TorrentUploadConfig | null): Promise<void> {
+export async function addTorrentToWebUiById(webUiId: string, url: string, config: TorrentUploadConfig | null, context: TorrentDownloadContext = {}): Promise<void> {
     const webUi = await getWebUiById(webUiId, new Settings());
-    downloadAndAddTorrentToWebUi(webUi, url, config, { action: AddTorrentMessage.action, url, webUiId } as IPreAddTorrentMessage);
+    downloadAndAddTorrentToWebUi(webUi, url, config, { action: AddTorrentMessage.action, url, webUiId } as IPreAddTorrentMessage, context);
 }
 
 async function testConnectionForWebUiSettings(webUiSettings: WebUISettings): Promise<ConnectionTestResult> {
@@ -196,10 +223,10 @@ async function getWebUiById(webUiId: string, settingsProvider: Settings): Promis
     return allWebUis.find(webUi => webUi.settings.id === webUiId) ?? null;
 }
 
-function downloadAndAddTorrentToWebUi(webUi: TorrentWebUI | null, url: string, config: TorrentUploadConfig | null, message: IPreAddTorrentMessage): void {
+function downloadAndAddTorrentToWebUi(webUi: TorrentWebUI | null, url: string, config: TorrentUploadConfig | null, message: IPreAddTorrentMessage, context: TorrentDownloadContext = {}): void {
     new Settings().loadSettings().then(settings => {
         if (webUi) {
-            downloadTorrent(url).then(torrent => {
+            downloadTorrent(url, context).then(torrent => {
                 const fallbackConfig: TorrentUploadConfig = {
                     addPaused: webUi.settings.addPaused,
                     dir: getAutoDirResult(torrent, webUi._settings.autoLabelDirSettings) ?? webUi.settings.defaultDir ?? undefined,
@@ -209,12 +236,7 @@ function downloadAndAddTorrentToWebUi(webUi: TorrentWebUI | null, url: string, c
                 sendTorrentToWebUi(webUi, torrent, config ?? fallbackConfig);
             }).catch(error => {
                 console.error("Error downloading torrent:", error);
-                showNotification("Error downloading torrent",
-                            `Error: ${error}`,
-                            true,
-                            settings.notificationsDurationMs,
-                            settings.notificationsSoundEnabled,
-                            addTrailingSlash(webUi.createBaseUrl()));
+                notifyDownloadFailure(error, settings, addTrailingSlash(webUi.createBaseUrl()));
             });
         } else {
             console.error("No WebUI found for addTorrentMessage:", message);
@@ -225,6 +247,25 @@ function downloadAndAddTorrentToWebUi(webUi: TorrentWebUI | null, url: string, c
                         settings.notificationsSoundEnabled);
         }
     });
+}
+
+function notifyDownloadFailure(error: unknown, settings: RTASettings, webUiUrl: string): void {
+    if (error instanceof CloudflareChallengeError) {
+        showNotification("Cloudflare is blocking this download",
+            error.message,
+            true,
+            settings.notificationsDurationMs,
+            settings.notificationsSoundEnabled,
+            error.challengeUrl);
+        return;
+    }
+
+    showNotification("Error downloading torrent",
+        `Error: ${error}`,
+        true,
+        settings.notificationsDurationMs,
+        settings.notificationsSoundEnabled,
+        webUiUrl);
 }
 
 /**

--- a/src/util/torrent-bytes.ts
+++ b/src/util/torrent-bytes.ts
@@ -1,0 +1,20 @@
+export const MAX_TORRENT_FILE_BYTES = 25 * 1024 * 1024;
+
+const BASE64_CHUNK_SIZE = 0x8000;
+
+export function bytesToBase64(bytes: Uint8Array): string {
+    let binary = "";
+    for (let offset = 0; offset < bytes.length; offset += BASE64_CHUNK_SIZE) {
+        binary += String.fromCharCode(...bytes.subarray(offset, offset + BASE64_CHUNK_SIZE));
+    }
+    return btoa(binary);
+}
+
+export function base64ToBytes(base64: string): Uint8Array<ArrayBuffer> {
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index++) {
+        bytes[index] = binary.charCodeAt(index);
+    }
+    return bytes;
+}

--- a/test/content-script/torrent-fetch.test.ts
+++ b/test/content-script/torrent-fetch.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { fetchTorrentInPage } from "../../src/content-script/torrent-fetch";
+import { base64ToBytes } from "../../src/util/torrent-bytes";
+import { mockResponse, queueFetch } from "../helpers/fetch-mock";
+
+describe("fetchTorrentInPage", () => {
+    it("fetches a same-origin link as the page itself would", async () => {
+        const fetch = queueFetch(mockResponse({ status: 200, body: "d4:infod4:name2:hieee" }));
+
+        const fetched = await fetchTorrentInPage(`${location.origin}/get/1.torrent`);
+
+        expect(fetch.mock.calls[0]![1]).toEqual({ mode: "same-origin", credentials: "include", redirect: "follow" });
+        expect(new TextDecoder().decode(base64ToBytes(fetched.base64))).toBe("d4:infod4:name2:hieee");
+        expect(fetched.ok).toBe(true);
+    });
+
+    it("uses cors mode for a link pointing at another host", async () => {
+        const fetch = queueFetch(mockResponse({ status: 200, body: "" }));
+
+        await fetchTorrentInPage("https://cdn.elsewhere.net/get/1.torrent");
+
+        expect((fetch.mock.calls[0]![1] as RequestInit).mode).toBe("cors");
+    });
+
+    it("reports the status, content type and cf-mitigated header back to the worker", async () => {
+        queueFetch(mockResponse({
+            status: 403,
+            body: "challenge",
+            url: "https://tracker.org/get/1.torrent?redirected",
+            headers: { "Content-Type": "text/html; charset=utf-8", "cf-mitigated": "challenge" },
+        }));
+
+        const fetched = await fetchTorrentInPage("https://tracker.org/get/1.torrent");
+
+        expect(fetched.ok).toBe(false);
+        expect(fetched.status).toBe(403);
+        expect(fetched.contentType).toBe("text/html; charset=utf-8");
+        expect(fetched.cfMitigated).toBe("challenge");
+        expect(fetched.finalUrl).toBe("https://tracker.org/get/1.torrent?redirected");
+    });
+
+    it("refuses to hand back a response too large to be a torrent file", async () => {
+        queueFetch(mockResponse({ status: 200, body: "x".repeat(25 * 1024 * 1024 + 1) }));
+
+        await expect(fetchTorrentInPage("https://tracker.org/get/1.torrent")).rejects.toThrow(/far too large/);
+    });
+});

--- a/test/popup/PageLinksView.test.tsx
+++ b/test/popup/PageLinksView.test.tsx
@@ -6,7 +6,7 @@ import { GetPageLinksMessage, PreAddTorrentMessage } from "../../src/models/mess
 
 beforeEach(() => {
     vi.spyOn(window, "close").mockImplementation(() => undefined);
-    (chrome.tabs.query as any).mockResolvedValue([{ id: 42 }]);
+    (chrome.tabs.query as any).mockResolvedValue([{ id: 42, url: "https://tracker.org/browse" }]);
 });
 
 describe("PageLinksView", () => {
@@ -53,6 +53,9 @@ describe("PageLinksView", () => {
         expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({
             action: PreAddTorrentMessage.action,
             url: "https://example.com/a.torrent",
+            tabId: 42,
+            frameId: 0,
+            pageUrl: "https://tracker.org/browse",
         });
         expect(window.close).toHaveBeenCalled();
     });

--- a/test/util/cors-tricks.test.ts
+++ b/test/util/cors-tricks.test.ts
@@ -58,6 +58,15 @@ describe("executeMethodWrappedWithReferer", () => {
         });
     });
 
+    it("also strips the extension origin from the request", async () => {
+        (chrome.declarativeNetRequest.getDynamicRules as any).mockResolvedValue([]);
+
+        await executeMethodWrappedWithReferer(async () => "result", "http://t/file", "http://t/page");
+
+        const addArg = (chrome.declarativeNetRequest.updateDynamicRules as any).mock.calls[0][0];
+        expect(addArg.addRules[0].action.requestHeaders[1]).toEqual({ header: "Origin", operation: "remove" });
+    });
+
     it("removes the referer rule even when the method throws", async () => {
         (chrome.declarativeNetRequest.getDynamicRules as any).mockResolvedValue([]);
         const failing = vi.fn(async () => {

--- a/test/util/download.test.ts
+++ b/test/util/download.test.ts
@@ -1,7 +1,31 @@
-import { describe, it, expect } from "vitest";
-import { downloadTorrent } from "../../src/util/download";
+import { describe, it, expect, vi } from "vitest";
+import { CloudflareChallengeError, downloadTorrent } from "../../src/util/download";
+import { FetchTorrentInPageMessage } from "../../src/models/messages";
+import { bytesToBase64 } from "../../src/util/torrent-bytes";
 import { mockResponse, queueFetch } from "../helpers/fetch-mock";
 import { buildBencodedTorrent } from "../helpers/fixtures";
+
+const CLOUDFLARE_CHALLENGE_BODY =
+    "<html><head><script src='/cdn-cgi/challenge-platform/h/b/orchestrate/chl_page/v1'></script></head></html>";
+
+function bencodedTorrent(name = "ubuntu.iso"): string {
+    return buildBencodedTorrent({ announce: "http://tracker.one/announce", info: { name } });
+}
+
+function pageResponse(body: string, over: Record<string, unknown> = {}) {
+    return {
+        fetched: {
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            contentType: "application/x-bittorrent",
+            cfMitigated: null,
+            finalUrl: "https://tracker.org/get/1.torrent",
+            base64: bytesToBase64(new TextEncoder().encode(body)),
+            ...over,
+        },
+    };
+}
 
 describe("downloadTorrent (magnet)", () => {
     it("returns magnet metadata without fetching", async () => {
@@ -60,5 +84,106 @@ describe("downloadTorrent (file)", () => {
     it("rejects with a helpful message when the body is not a torrent", async () => {
         queueFetch(mockResponse({ status: 200, body: "<html>nope</html>", headers: { "Content-Type": "text/html; charset=utf-8" } }));
         await expect(downloadTorrent("https://site.com/fake.torrent")).rejects.toThrow(/text\/html instead of a torrent/);
+    });
+
+    it("keeps the whole content type when it carries no parameters", async () => {
+        queueFetch(mockResponse({ status: 200, body: "<html>nope</html>", headers: { "Content-Type": "text/html" } }));
+        await expect(downloadTorrent("https://site.com/fake.torrent")).rejects.toThrow(/Received text\/html instead/);
+    });
+
+    it("sends cookies and a page referer with the worker request", async () => {
+        const fetch = queueFetch(mockResponse({ status: 200, body: bencodedTorrent() }));
+
+        await downloadTorrent("https://tracker.org/get/1.torrent", { pageUrl: "https://tracker.org/browse?id=7" });
+
+        expect(fetch.mock.calls[0]![1]).toEqual({ credentials: "include" });
+        const addedRule = (chrome.declarativeNetRequest.updateDynamicRules as any).mock.calls[0][0].addRules[0];
+        expect(addedRule.action.requestHeaders).toEqual([
+            { header: "Referer", operation: "set", value: "https://tracker.org/browse?id=7" },
+            { header: "Origin", operation: "remove" },
+        ]);
+    });
+
+    it("refuses a response too large to be a torrent file", async () => {
+        queueFetch(mockResponse({ status: 200, body: "x".repeat(25 * 1024 * 1024 + 1) }));
+        await expect(downloadTorrent("https://site.com/huge.torrent")).rejects.toThrow(/far too large/);
+    });
+});
+
+describe("downloadTorrent (through the page)", () => {
+    it("asks the clicked tab's frame to fetch the torrent and never touches the worker's fetch", async () => {
+        const fetch = queueFetch(mockResponse({ status: 200 }));
+        (chrome.tabs.sendMessage as any).mockResolvedValue(pageResponse(bencodedTorrent()));
+
+        const torrent = await downloadTorrent("https://tracker.org/get/1.torrent", { tabId: 9, frameId: 3 });
+
+        expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(
+            9,
+            { action: FetchTorrentInPageMessage.action, url: "https://tracker.org/get/1.torrent" },
+            { frameId: 3 },
+        );
+        expect(fetch).not.toHaveBeenCalled();
+        expect(torrent.name).toBe("ubuntu.iso");
+    });
+
+    it("falls back to the worker when no content script answers", async () => {
+        vi.spyOn(console, "warn").mockImplementation(() => undefined);
+        const fetch = queueFetch(mockResponse({ status: 200, body: bencodedTorrent("from-worker") }));
+        (chrome.tabs.sendMessage as any).mockRejectedValue(new Error("Could not establish connection."));
+
+        const torrent = await downloadTorrent("https://tracker.org/get/1.torrent", { tabId: 9 });
+
+        expect(fetch).toHaveBeenCalled();
+        expect(torrent.name).toBe("from-worker");
+    });
+
+    it("falls back to the worker when the page's fetch failed", async () => {
+        vi.spyOn(console, "warn").mockImplementation(() => undefined);
+        const fetch = queueFetch(mockResponse({ status: 200, body: bencodedTorrent("from-worker") }));
+        (chrome.tabs.sendMessage as any).mockResolvedValue({ error: "Failed to fetch" });
+
+        await downloadTorrent("https://tracker.org/get/1.torrent", { tabId: 9 });
+
+        expect(fetch).toHaveBeenCalled();
+    });
+
+    it("does not retry through the worker when the page itself was challenged", async () => {
+        const fetch = queueFetch(mockResponse({ status: 200, body: bencodedTorrent() }));
+        (chrome.tabs.sendMessage as any).mockResolvedValue(pageResponse(CLOUDFLARE_CHALLENGE_BODY, {
+            ok: false,
+            status: 403,
+            contentType: "text/html; charset=utf-8",
+            base64: bytesToBase64(new TextEncoder().encode(CLOUDFLARE_CHALLENGE_BODY)),
+        }));
+
+        await expect(downloadTorrent("https://tracker.org/get/1.torrent", { tabId: 9 })).rejects.toThrow(CloudflareChallengeError);
+        expect(fetch).not.toHaveBeenCalled();
+    });
+});
+
+describe("downloadTorrent (cloudflare)", () => {
+    it("recognizes a challenge from the cf-mitigated header", async () => {
+        queueFetch(mockResponse({ status: 403, body: "", headers: { "cf-mitigated": "challenge" } }));
+
+        await expect(downloadTorrent("https://tracker.org/get/1.torrent"))
+            .rejects.toThrow(/Open the link in a tab/);
+    });
+
+    it("recognizes a challenge from the interstitial body", async () => {
+        queueFetch(mockResponse({
+            status: 403,
+            body: CLOUDFLARE_CHALLENGE_BODY,
+            headers: { "Content-Type": "text/html; charset=utf-8" },
+        }));
+
+        const error = await downloadTorrent("https://tracker.org/get/1.torrent").catch((e: unknown) => e);
+        expect(error).toBeInstanceOf(CloudflareChallengeError);
+        expect((error as CloudflareChallengeError).challengeUrl).toBe("https://tracker.org/get/1.torrent");
+    });
+
+    it("leaves an ordinary 403 alone", async () => {
+        queueFetch(mockResponse({ status: 403, body: "no", headers: { "Content-Type": "text/html" } }));
+
+        await expect(downloadTorrent("https://tracker.org/get/1.torrent")).rejects.toThrow(/Status not OK: 403/);
     });
 });

--- a/test/util/messaging.test.ts
+++ b/test/util/messaging.test.ts
@@ -7,7 +7,10 @@ const { showNotification, downloadTorrent } = vi.hoisted(() => ({
     downloadTorrent: vi.fn(),
 }));
 vi.mock("../../src/util/notifications", () => ({ showNotification }));
-vi.mock("../../src/util/download", () => ({ downloadTorrent }));
+vi.mock("../../src/util/download", async (importOriginal) => ({
+    ...(await importOriginal<Record<string, unknown>>()),
+    downloadTorrent,
+}));
 
 import { registerMessageListener, dispatchPreAddTorrent } from "../../src/util/messaging";
 import {
@@ -23,6 +26,7 @@ import { getDefaultSettings } from "../../src/util/settings-defaults";
 import { Client } from "../../src/models/clients";
 import { makeWebUISettings, makeMagnetTorrent, makeFileTorrent } from "../helpers/fixtures";
 import { readBufferedTorrent, saveBufferedTorrent } from "../../src/util/buffered-torrent";
+import { CloudflareChallengeError } from "../../src/util/download";
 
 /** Registers the listener and returns it so tests can invoke it directly. */
 function getListener() {
@@ -108,7 +112,7 @@ describe("AddTorrent flow", () => {
         await dispatch({ action: AddTorrentMessage.action, webUiId: "w1", url: "magnet:?x", config: {} });
         await new Promise((r) => setTimeout(r, 0));
 
-        expect(downloadTorrent).toHaveBeenCalledWith("magnet:?x");
+        expect(downloadTorrent).toHaveBeenCalledWith("magnet:?x", { tabId: null, frameId: 0, pageUrl: null });
         expect(showNotification).toHaveBeenCalled();
         expect(callArgs(showNotification, 0)[0]).toBe("Torrent added successfully");
     });
@@ -122,6 +126,37 @@ describe("AddTorrent flow", () => {
 
         expect(showNotification).toHaveBeenCalled();
         expect(callArgs(showNotification, 0)[0]).toBe("Error downloading torrent");
+    });
+
+    it("hands the download over to the tab the link was clicked in", async () => {
+        seedWebUi();
+        downloadTorrent.mockResolvedValue(makeMagnetTorrent());
+        (globalThis as any).fetch = vi.fn(() =>
+            Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve("Ok.") } as any),
+        );
+
+        await dispatch(
+            { action: AddTorrentMessage.action, webUiId: "w1", url: "https://tracker.org/get/1.torrent", config: {} },
+            { tab: { id: 9, windowId: 1, url: "https://tracker.org/browse" }, frameId: 3 },
+        );
+        await new Promise((r) => setTimeout(r, 0));
+
+        expect(downloadTorrent).toHaveBeenCalledWith("https://tracker.org/get/1.torrent", {
+            tabId: 9,
+            frameId: 3,
+            pageUrl: "https://tracker.org/browse",
+        });
+    });
+
+    it("points the notification at the tracker when Cloudflare challenges the download", async () => {
+        seedWebUi();
+        downloadTorrent.mockRejectedValue(new CloudflareChallengeError("https://tracker.org/get/1.torrent"));
+
+        await dispatch({ action: AddTorrentMessage.action, webUiId: "w1", url: "https://tracker.org/get/1.torrent", config: {} });
+        await new Promise((r) => setTimeout(r, 0));
+
+        expect(callArgs(showNotification, 0)[0]).toBe("Cloudflare is blocking this download");
+        expect(callArgs(showNotification, 0)[5]).toBe("https://tracker.org/get/1.torrent");
     });
 
     it("persists updated labels and dirs for AddTorrentMessageWithLabelAndDir", async () => {
@@ -224,10 +259,30 @@ describe("dispatchPreAddTorrent", () => {
             Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve("Ok.") } as any),
         );
 
-        await dispatchPreAddTorrent({ action: PreAddTorrentMessage.action, url: "magnet:?x", webUiId: "w1" }, 1);
+        await dispatchPreAddTorrent(
+            { action: PreAddTorrentMessage.action, url: "magnet:?x", webUiId: "w1" },
+            1,
+            { tabId: 4, frameId: 0, pageUrl: "https://tracker.org/browse" },
+        );
         await new Promise((r) => setTimeout(r, 0));
 
-        expect(downloadTorrent).toHaveBeenCalledWith("magnet:?x");
+        expect(downloadTorrent).toHaveBeenCalledWith("magnet:?x", { tabId: 4, frameId: 0, pageUrl: "https://tracker.org/browse" });
+    });
+
+    it("notifies instead of opening the popup when the download fails", async () => {
+        const settings = getDefaultSettings();
+        settings.webuiSettings = [
+            makeWebUISettings({ id: "w1", client: Client.QBittorrentWebUI, showPerTorrentConfigSelector: true }),
+        ];
+        (chrome as any).__storage.settings = serializeSettings(settings);
+        downloadTorrent.mockRejectedValue(new CloudflareChallengeError("https://tracker.org/get/1.torrent"));
+
+        await dispatchPreAddTorrent({ action: PreAddTorrentMessage.action, url: "https://tracker.org/get/1.torrent", webUiId: "w1" }, 7);
+        await new Promise((r) => setTimeout(r, 0));
+
+        expect(callArgs(showNotification, 0)[0]).toBe("Cloudflare is blocking this download");
+        expect(chrome.action.openPopup).not.toHaveBeenCalled();
+        expect(await readBufferedTorrent()).toBeNull();
     });
 
     it("buffers the torrent and opens the popup when the selector is enabled", async () => {

--- a/test/util/torrent-bytes.test.ts
+++ b/test/util/torrent-bytes.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { base64ToBytes, bytesToBase64 } from "../../src/util/torrent-bytes";
+
+describe("torrent bytes over the message channel", () => {
+    it("round-trips arbitrary binary content", () => {
+        const bytes = new Uint8Array(1024);
+        for (let index = 0; index < bytes.length; index++) {
+            bytes[index] = index % 256;
+        }
+
+        expect(base64ToBytes(bytesToBase64(bytes))).toEqual(bytes);
+    });
+
+    it("round-trips a payload larger than one encoding chunk", () => {
+        const bytes = new Uint8Array(0x8000 * 3 + 17);
+        for (let index = 0; index < bytes.length; index++) {
+            bytes[index] = (index * 31 + 7) % 256;
+        }
+
+        expect(base64ToBytes(bytesToBase64(bytes))).toEqual(bytes);
+    });
+
+    it("round-trips an empty payload", () => {
+        expect(bytesToBase64(new Uint8Array(0))).toBe("");
+        expect(base64ToBytes("")).toEqual(new Uint8Array(0));
+    });
+});


### PR DESCRIPTION
move torrent file download into the content script (from the service worker). this guarantees that most of the headers that e.g. cloudflare would heuristically flag as bot behavior are set just like if a user were to click a link. adds a bit of additional messaging, and there's a fallback route if the initiating tab/frame doesn't exist - the download is then executed in the service worker without CF compatibility.

fixes #498