### PR TITLE
fix(options): reset the WebUI detail panel when switching WebUIs

### DIFF
--- a/src/options/pages/WebUIsPage.tsx
+++ b/src/options/pages/WebUIsPage.tsx
@@ -595,6 +595,7 @@ export default function WebUIsPage() {
       <div style={{ flex: 1, minWidth: 0 }}>
         {selected ? (
           <WebUIDetail
+            key={selected.id}
             webui={selected}
             onChange={updated => handleChange(selected.id, updated)}
             onRemove={() => handleRemove(selected.id)}

--- a/test/options/pages/WebUIsPage.test.tsx
+++ b/test/options/pages/WebUIsPage.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SettingsProvider } from "../../../src/options/SettingsContext";
+import WebUIsPage from "../../../src/options/pages/WebUIsPage";
+import { GetSettingsMessage, SaveSettingsMessage } from "../../../src/models/messages";
+import { serializeSettings, deserializeSettings } from "../../../src/util/serializer";
+import { getDefaultSettings } from "../../../src/util/settings-defaults";
+import { makeWebUISettings } from "../../helpers/fixtures";
+
+function respondWithWebUIs(webuiSettings = [makeWebUISettings({ id: "a", name: "Alpha" }), makeWebUISettings({ id: "b", name: "Beta" })]) {
+    const settings = getDefaultSettings();
+    settings.webuiSettings = webuiSettings;
+    (chrome.runtime.sendMessage as any).mockImplementation((message: any, callback?: (r: any) => void) => {
+        if (message.action === GetSettingsMessage.action) {
+            callback?.(serializeSettings(settings));
+        }
+        return Promise.resolve();
+    });
+}
+
+const savedWebUIs = () => {
+    const save = (chrome.runtime.sendMessage as any).mock.calls
+        .map((call: any[]) => call[0])
+        .findLast((message: any) => message?.action === SaveSettingsMessage.action);
+    return save ? deserializeSettings(save.settings)!.webuiSettings : null;
+};
+
+const renderPage = () => render(<SettingsProvider><WebUIsPage /></SettingsProvider>);
+
+describe("WebUIsPage", () => {
+    it("removes the selected WebUI once the removal is confirmed", async () => {
+        respondWithWebUIs();
+        renderPage();
+
+        await userEvent.click(await screen.findByRole("button", { name: "Remove" }));
+        await userEvent.click(screen.getByRole("button", { name: "For real?" }));
+
+        expect(savedWebUIs()!.map(w => w.id)).toEqual(["b"]);
+    });
+
+    it("keeps the selected WebUI when the removal is cancelled", async () => {
+        respondWithWebUIs();
+        renderPage();
+
+        await userEvent.click(await screen.findByRole("button", { name: "Remove" }));
+        await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+        expect(screen.getByRole("button", { name: "Remove" })).toBeInTheDocument();
+        expect(savedWebUIs()).toBeNull();
+    });
+
+    it("disarms a pending removal confirmation when another WebUI is selected", async () => {
+        respondWithWebUIs();
+        renderPage();
+
+        await userEvent.click(await screen.findByRole("button", { name: "Remove" }));
+        expect(screen.getByRole("button", { name: "For real?" })).toBeInTheDocument();
+
+        await userEvent.click(screen.getByText("Beta"));
+
+        expect(screen.getByRole("button", { name: "Remove" })).toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: "For real?" })).not.toBeInTheDocument();
+    });
+
+    it("re-arms the confirmation independently after switching back", async () => {
+        respondWithWebUIs();
+        renderPage();
+
+        await userEvent.click(await screen.findByRole("button", { name: "Remove" }));
+        await userEvent.click(screen.getByText("Beta"));
+        await userEvent.click(screen.getByText("Alpha"));
+
+        expect(screen.getByRole("button", { name: "Remove" })).toBeInTheDocument();
+        expect(savedWebUIs()).toBeNull();
+    });
+});


### PR DESCRIPTION
Keying WebUIDetail on the selected id remounts it per selection, so a pending "For real?" removal confirmation - and any other transient panel state, like a half-typed chip input - no longer carries over to the next WebUI the user clicks.